### PR TITLE
Make CUDA.jl work on v0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.2-
+julia 0.4

--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -31,7 +31,7 @@ module CUDA
     CuPtr, CuArray, free, to_host
 
     const CUDA_LIB = @windows? "nvcuda.dll" : "libcuda"
-    dlopen(CUDA_LIB)    # loads library, throws an error if not found
+    Libdl.dlopen(CUDA_LIB)    # loads library, throws an error if not found
 
     include("errors.jl")
     include("funmap.jl")

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -1,6 +1,6 @@
 # Arrays on GPU
 
-typealias CUdeviceptr Uint64
+typealias CUdeviceptr UInt64
 
 immutable CuPtr
     p::CUdeviceptr

--- a/src/base.jl
+++ b/src/base.jl
@@ -8,7 +8,7 @@ macro cucall(fv, argtypes, args...)
     quote
         _curet = ccall( ($(Meta.quot(f)), CUDA_LIB), Cint, $argtypes, $(args...) )
         if _curet != 0
-            throw(CuDriverError(int(_curet)))
+            throw(CuDriverError(Int(_curet)))
         end
     end
 end
@@ -26,7 +26,7 @@ initialize()
 function driver_version()
     a = Cint[0]
     @cucall(cuDriverGetVersion, (Ptr{Cint},), a)
-    return int(a[1])
+    return Int(a[1])
 end
 
 const DriverVersion = driver_version()

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -1,7 +1,7 @@
 # CUDA errors
 
 
-const driver_error_descriptions = (Int=>ASCIIString)[
+const driver_error_descriptions = Dict{Int,ASCIIString}(
     0 => "Success",
     1 => "Invalid value",
     2 => "Out of memory",
@@ -59,7 +59,7 @@ const driver_error_descriptions = (Int=>ASCIIString)[
     800 => "Operation not permitted",
     801 => "Operation not supported",
     999 => "Unknown error"
-]
+)
 
 
 immutable CuDriverError

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -12,7 +12,7 @@ get_dim_z(g::Int) = 1
 get_dim_z(g::Tuple{Int, Int}) = 1
 get_dim_z(g::Tuple{Int, Int, Int}) = g[3]
 
-typealias CuDim Union(Int, Tuple{Int, Int}, Tuple{Int, Int, Int})
+typealias CuDim Union{Int, Tuple{Int, Int}, Tuple{Int, Int, Int}}
 
 # Stream management
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -1,18 +1,18 @@
 # CUDA Execution control
 
 get_dim_x(g::Int) = g
-get_dim_x(g::(Int, Int)) = g[1]
-get_dim_x(g::(Int, Int, Int)) = g[1]
+get_dim_x(g::Tuple{Int, Int}) = g[1]
+get_dim_x(g::Tuple{Int, Int, Int}) = g[1]
 
 get_dim_y(g::Int) = 1
-get_dim_y(g::(Int, Int)) = g[2]
-get_dim_y(g::(Int, Int, Int)) = g[2]
+get_dim_y(g::Tuple{Int, Int}) = g[2]
+get_dim_y(g::Tuple{Int, Int, Int}) = g[2]
 
 get_dim_z(g::Int) = 1
-get_dim_z(g::(Int, Int)) = 1
-get_dim_z(g::(Int, Int, Int)) = g[3]
+get_dim_z(g::Tuple{Int, Int}) = 1
+get_dim_z(g::Tuple{Int, Int, Int}) = g[3]
 
-typealias CuDim Union(Int, (Int, Int), (Int, Int, Int))
+typealias CuDim Union(Int, Tuple{Int, Int}, Tuple{Int, Int, Int})
 
 # Stream management
 


### PR DESCRIPTION
Julia v0.4 didn't like the `(Int,Int)` and preferred `Tuple{Int,Int}` instead. Fixes #10 
