### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Julia Programming interface for CUDA.
 
 This package wraps key functions in CUDA Driver API for Julia. While this remains work in progress, simple use is ready. See also the [CUDArt package](https://github.com/JuliaGPU/CUDArt.jl).
 
-**Note:** This package was tested on Ubuntu (13.04 or above) and Mac OS X (10.8+). It has not been tested thoroughly on Windows.
+**Note:** This package was tested on Ubuntu (13.04 or above), Mac OS X (10.8+), and Windows 10.
 
 ### Setup
 


### PR DESCRIPTION
I personally have been running CUDA kernals through CUDA.jl (even compiling on one computer, sending the bytecode, and using it on the other). From my use I'd say it's safe to say it works (at least on Windows 10, using cl.exe from Visual Studio 12).
