### PR TITLE
Add a short note stating that development stopped.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# End of life announcement
+Development of this package has moved on to [CUDArt.jl](https://github.com/JuliaGPU/CUDArt.jl). We currently only keep this package around as a point of reference and for backwards compability. There will no longer be any **new** funcionality added to this package (bugfixes still welcome). 
+
+Expect a full deprecation of this package with Julia `v0.5`.
+
+___
+
 ## CUDA.jl
 
 Julia Programming interface for CUDA.


### PR DESCRIPTION
I think this is fair to say and about time, also see discussion in https://github.com/JuliaGPU/CUDA.jl/pull/16.

@maleadt You were thinking or ripping the high-level abstraction layers out of CUDA.jl and keeping the low-level functionality, right? I was wondering about how to best do that without causing pain to users that are currently using CUDA.jl.

cc: @lindahua @timholy 
